### PR TITLE
1K Level: add Giant / Speed / Power random powerups

### DIFF
--- a/1k-level.html
+++ b/1k-level.html
@@ -76,6 +76,26 @@
     touch-action: none;
   }
 
+  .powerup-hud {
+    position: absolute;
+    top: 8px; left: 50%; transform: translateX(-50%);
+    display: flex; align-items: center; gap: 8px;
+    background: rgba(13, 16, 36, 0.85);
+    border: 1px solid var(--pu-color, var(--accent));
+    border-radius: 999px;
+    padding: 4px 12px 4px 10px;
+    font-size: 12px;
+    font-weight: 800;
+    letter-spacing: 1px;
+    box-shadow: 0 0 12px var(--pu-color, var(--accent));
+    z-index: 5;
+    pointer-events: none;
+  }
+  .powerup-hud.hidden { display: none; }
+  .pu-name { color: var(--pu-color, var(--accent)); }
+  .pu-bar  { width: 70px; height: 4px; background: rgba(255,255,255,0.1); border-radius: 2px; overflow: hidden; }
+  .pu-fill { height: 100%; background: var(--pu-color, var(--accent)); width: 100%; }
+
   /* Overlay (splash + game over) */
   .overlay {
     position: fixed; inset: 0;
@@ -162,6 +182,10 @@
 
   <div class="stage" id="stage">
     <canvas id="canvas"></canvas>
+    <div class="powerup-hud hidden" id="powerupHud">
+      <span class="pu-name" id="pu-name"></span>
+      <div class="pu-bar"><div class="pu-fill" id="pu-fill"></div></div>
+    </div>
   </div>
 
   <div class="overlay" id="overlay">
@@ -191,6 +215,25 @@
   const scoreEl = document.getElementById('score');
   const ballsEl = document.getElementById('balls');
 
+  const powerupHud = document.getElementById('powerupHud');
+  const puName = document.getElementById('pu-name');
+  const puFill = document.getElementById('pu-fill');
+
+  function showPowerupHud(type) {
+    const info = POWERUP_INFO[type];
+    powerupHud.style.setProperty('--pu-color', info.color);
+    puName.textContent = info.label;
+    puFill.style.width = '100%';
+    powerupHud.classList.remove('hidden');
+  }
+  function hidePowerupHud() { powerupHud.classList.add('hidden'); }
+  function updatePowerupHud() {
+    if (!state.powerup) return;
+    const remaining = state.powerup.expiresAt - performance.now();
+    const pct = Math.max(0, remaining / POWERUP_DURATION) * 100;
+    puFill.style.width = pct + '%';
+  }
+
   let dpr = Math.max(1, window.devicePixelRatio || 1);
   function fitCanvas() {
     const r = stage.getBoundingClientRect();
@@ -216,9 +259,110 @@
     field: { w: 0, h: 0 },
     ball: null,        // { x, y, vx, vy, r, value, launched }
     lastFrame: 0,
-    particles: [],     // { x, y, vx, vy, color, life, ttl, size }
-    stars: [],         // background twinkles
+    particles: [],
+    stars: [],
+    drops: [],         // { x, y, vy, type } powerup tokens falling from kills
+    powerup: null,     // { type, expiresAt } currently active powerup
   };
+
+  // ---------------- Powerups ----------------
+  const POWERUP_INFO = {
+    giant: { label: 'GIANT', color: '#5fd4ff', glyph: 'G' },
+    speed: { label: 'SPEED', color: '#ffd166', glyph: 'S' },
+    power: { label: 'POWER', color: '#ff5277', glyph: 'P' },
+  };
+  const POWERUP_TYPES = Object.keys(POWERUP_INFO);
+  const POWERUP_DURATION = 7000;       // ms
+  const POWERUP_DROP_CHANCE = 0.25;    // per brick destroyed
+  const DROP_FALL_SPEED = 90;          // px/s
+  const DROP_R = 22;
+  const DROP_TAP_R = 38;               // generous finger-friendly hit-box
+
+  function maybeSpawnDrop(brick) {
+    if (Math.random() >= POWERUP_DROP_CHANCE) return;
+    const type = POWERUP_TYPES[Math.floor(Math.random() * POWERUP_TYPES.length)];
+    state.drops.push({
+      x: brick.x + brick.w / 2,
+      y: brick.y + brick.h / 2,
+      vy: DROP_FALL_SPEED,
+      type,
+    });
+  }
+
+  function updateDrops(dt) {
+    for (let i = state.drops.length - 1; i >= 0; i--) {
+      const d = state.drops[i];
+      d.y += d.vy * dt;
+      if (d.y > state.field.h + DROP_R + 20) state.drops.splice(i, 1);
+    }
+  }
+
+  function drawDrops() {
+    for (const d of state.drops) {
+      const info = POWERUP_INFO[d.type];
+      ctx.save();
+      // Pulsing glow
+      const t = performance.now() / 1000;
+      const pulse = (Math.sin(t * 4) + 1) / 2;
+      ctx.shadowColor = info.color;
+      ctx.shadowBlur = 8 + pulse * 10;
+      ctx.fillStyle = info.color;
+      ctx.beginPath(); ctx.arc(d.x, d.y, DROP_R, 0, Math.PI * 2); ctx.fill();
+      ctx.shadowBlur = 0;
+      // Inner dark disc
+      ctx.fillStyle = '#0d1024';
+      ctx.beginPath(); ctx.arc(d.x, d.y, DROP_R - 4, 0, Math.PI * 2); ctx.fill();
+      // Glyph
+      ctx.fillStyle = info.color;
+      ctx.font = '800 22px -apple-system, "Segoe UI", Roboto, sans-serif';
+      ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+      ctx.fillText(info.glyph, d.x, d.y + 1);
+      ctx.restore();
+    }
+  }
+
+  function activatePowerup(type) {
+    // If already active, expire current effects cleanly first.
+    if (state.powerup) deactivatePowerup();
+    state.powerup = { type, expiresAt: performance.now() + POWERUP_DURATION };
+    const b = state.ball;
+    if (!b) return;
+    if (type === 'giant') {
+      b.r = BALL_R * 3;
+    } else if (type === 'speed') {
+      b.vx *= 2;
+      b.vy *= 2;
+    }
+    // 'power' is just a flag; the damage multiplier is applied at hit time.
+    showPowerupHud(type);
+  }
+
+  function deactivatePowerup() {
+    if (!state.powerup) return;
+    const b = state.ball;
+    if (b) {
+      if (state.powerup.type === 'giant') b.r = BALL_R;
+      else if (state.powerup.type === 'speed') { b.vx /= 2; b.vy /= 2; }
+    }
+    state.powerup = null;
+    hidePowerupHud();
+  }
+
+  function tickPowerup() {
+    if (!state.powerup) return;
+    if (performance.now() > state.powerup.expiresAt) {
+      deactivatePowerup();
+      return;
+    }
+    updatePowerupHud();
+  }
+
+  function damageMult() {
+    return state.powerup && state.powerup.type === 'power' ? 3 : 1;
+  }
+  function platformImmune() {
+    return state.powerup && state.powerup.type === 'speed';
+  }
 
   // ---------------- Audio ----------------
   const audio = {
@@ -499,7 +643,7 @@
     if (!n) return;
     reflect(b, n);
     // Apply damage: brick loses ball.value; ball grows by random amount.
-    const dmg = Math.min(best.value, b.value);
+    const dmg = Math.min(best.value, b.value * damageMult());
     best.value -= dmg;
     state.score += dmg;
     scoreEl.textContent = state.score;
@@ -511,6 +655,7 @@
     if (best.value <= 0) {
       best.value = 0;
       onBrickDestroyed(best);
+      maybeSpawnDrop(best);
     }
     b.value += ballGrowRoll();
   }
@@ -607,10 +752,12 @@
     if (b.x + b.r > state.field.w) { b.x = state.field.w - b.r; b.vx = -Math.abs(b.vx); }
     if (b.y - b.r < 0) { b.y = b.r; b.vy = Math.abs(b.vy); }
     // Bottom: anywhere along the floor that ISN'T inside the danger platform
-    // is a regular bouncy wall. The danger platform itself destroys the ball.
+    // is a regular bouncy wall. The danger platform itself destroys the ball,
+    // unless Speed Surge is active (the ball bounces off the platform too).
     if (b.y + b.r > state.field.h) {
       const plat = platformRect();
-      if (b.x >= plat.x && b.x <= plat.x + plat.w) {
+      const onPlat = b.x >= plat.x && b.x <= plat.x + plat.w;
+      if (onPlat && !platformImmune()) {
         loseBall();
         return;
       }
@@ -801,6 +948,7 @@
     drawStars();
     drawBricks();
     drawPlatform();
+    drawDrops();
     drawParticles();
     drawBall();
     drawAim();
@@ -813,7 +961,9 @@
     const dt = Math.min(0.05, (t - state.lastFrame) / 1000);
     state.lastFrame = t;
     updateBall(dt);
+    updateDrops(dt);
     updateParticles(dt);
+    tickPowerup();
     render();
     requestAnimationFrame(frame);
   }
@@ -846,8 +996,24 @@
     return dx * dx + dy * dy <= hit * hit;
   }
 
+  function tryTapDrop(p) {
+    for (let i = state.drops.length - 1; i >= 0; i--) {
+      const d = state.drops[i];
+      const dx = p.x - d.x, dy = p.y - d.y;
+      if (dx * dx + dy * dy <= DROP_TAP_R * DROP_TAP_R) {
+        activatePowerup(d.type);
+        state.drops.splice(i, 1);
+        return true;
+      }
+    }
+    return false;
+  }
+
   function onPointerDown(p) {
     if (!state.playing || !state.ball) return;
+    // Drops first — a token sitting near the ball shouldn't be eaten by
+    // a tap-on-ball.
+    if (tryTapDrop(p)) return;
     const b = state.ball;
     if (!b.launched) {
       if (pointInBall(p)) launchBall();
@@ -981,6 +1147,8 @@
     buildStars();
     spawnBall();
     state.particles.length = 0;
+    state.drops.length = 0;
+    deactivatePowerup();
     hideOverlay();
     startMusic();
     requestAnimationFrame(frame);


### PR DESCRIPTION
## Summary

Adds three random powerups to 1K Level. Destroyed bricks have a **25% chance to drop a token**; tapping the token activates the powerup for **7 seconds**.

## Powerups

| Glyph | Name | Effect |
|:---:|---|---|
| **G** | GIANT | Ball radius ×3 (visual + physics). Easier to hit bricks, harder to thread gaps. |
| **S** | SPEED | Ball velocity ×2 **and** the danger platform becomes a normal bouncy wall — you can dive low without losing the ball. |
| **P** | POWER | Damage dealt to bricks is ×3 ball.value (ball.value unchanged, so growth math is unaffected). |

## Drop & activation

- Token spawns at the destroyed brick's center, falls slowly (90 px/s), expires off-screen.
- Tap hit-box is 38px (finger-friendly), checked **before** the ball-tap so a token resting near the ball can't be eaten by an aim-tap.
- Active powerup shows a glowing pill at the top of the play area with the type's accent color and a draining timer bar.
- Activating a new powerup mid-timer cleanly deactivates the old one first — no stacking glitches (9× speed, 9× radius, etc.).
- Game start (new run) clears any leftover state.

## Test plan

- [ ] Destroy ~4 bricks; eventually a glowing token (G/S/P) drops.
- [ ] Tap the token mid-fall — pill appears at top, timer bar drains over 7s.
- [ ] **G**: ball visibly grows; collisions with bricks still feel right.
- [ ] **S**: ball moves faster, hitting the platform reflects instead of losing a ball.
- [ ] **P**: bricks crumble in roughly a third of the usual hits.
- [ ] Powerup expires automatically after 7s (pill disappears, ball returns to normal).
- [ ] Picking up a second token while one is active replaces it cleanly.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WXWzS2tPXX1ToZYjUF15Nc)_