### PR TITLE
Shelf Organization: 3-wide shelves, NEXT queue, board-full lose

### DIFF
--- a/shelf-organization.html
+++ b/shelf-organization.html
@@ -364,6 +364,50 @@
     z-index: 3;
   }
 
+  /* "NEXT" tray for upcoming spawn */
+  .next-tray {
+    width: 100%;
+    max-width: 360px;
+    margin: 4px auto 4px;
+    padding: 10px 14px;
+    background: var(--panel);
+    border-radius: 14px;
+    box-shadow: 0 4px 0 rgba(58,36,18,0.12);
+    display: flex; align-items: center; gap: 12px;
+    border: 2px dashed rgba(58,36,18,0.18);
+  }
+  .next-label {
+    font-size: 10px;
+    letter-spacing: 1.5px;
+    color: var(--ink-soft);
+    text-transform: uppercase;
+    flex: 1;
+    text-align: left;
+    line-height: 1.2;
+  }
+  .next-items {
+    display: flex; gap: 6px;
+  }
+  .next-items .next-item {
+    width: 38px; height: 38px;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 26px;
+    background: linear-gradient(180deg, #fff8ec 0%, #ffe5b8 100%);
+    border-radius: 8px;
+    box-shadow:
+      0 2px 0 rgba(0,0,0,0.18),
+      inset 0 1px 0 rgba(255,255,255,0.8);
+    line-height: 1;
+  }
+  @keyframes spawnPop {
+    0%   { transform: scale(0.4); opacity: 0; }
+    60%  { transform: scale(1.2); }
+    100% { transform: scale(1); opacity: 1; }
+  }
+  .item.front.spawning {
+    animation: spawnPop 0.32s ease-out;
+  }
+
   /* level-clear and game over overlays */
   .overlay {
     position: fixed; inset: 0;
@@ -511,6 +555,10 @@
         <div class="hud-tile"><span class="lbl">Items</span><span class="val" id="hud-items">0</span></div>
       </div>
       <div id="shelf-stack" class="shelf-stack" aria-label="shelves"></div>
+      <div id="next-tray" class="next-tray" aria-label="next items">
+        <span class="next-label">NEXT BAD MOVE SPAWNS</span>
+        <div class="next-items" id="next-items"></div>
+      </div>
     </section>
 
     <!-- Result screen -->
@@ -794,28 +842,33 @@
       totalTime,
       timerInterval: null,
       ended: false,
+      queue: genSpawnSet(board.items),
     };
     hardSlot.innerHTML = board.hard ? '<div class="hard-banner">⚠ HARD LEVEL ⚠</div>' : '';
     renderBoard(board);
+    renderQueue();
     setTimerDisplay(state.timeLeft);
     state.timerInterval = setInterval(() => {
       if (!state || state.ended) return;
       state.timeLeft -= 1;
       setTimerDisplay(Math.max(0, state.timeLeft));
       if (state.timeLeft <= 0) {
-        endRun();
+        endRun('time');
       }
     }, 1000);
   }
 
-  function endRun() {
+  function endRun(reason) {
     if (!state || state.ended) return;
     state.ended = true;
     clearTimer();
     refreshRecord();
-    document.getElementById('result-emoji').textContent = '🥲';
-    document.getElementById('result-title').textContent = "Time's Up!";
-    document.getElementById('result-sub').textContent = 'The pantry got the better of you.';
+    const isFull = reason === 'full';
+    document.getElementById('result-emoji').textContent = isFull ? '😵' : '🥲';
+    document.getElementById('result-title').textContent = isFull ? 'Pantry Overflowed!' : "Time's Up!";
+    document.getElementById('result-sub').textContent = isFull
+      ? 'No empty space left. The clutter wins.'
+      : 'The pantry got the better of you.';
     document.getElementById('result-level').textContent = state.level;
     document.getElementById('result-best').textContent = loadBest() || '—';
     show('result');
@@ -944,7 +997,13 @@
     fromCell.front = fromCell.back; // back item moves up to front
     fromCell.back = null;
     renderBoard(board);
-    resolveMatches();
+    resolveMatches((cleared) => {
+      if (state.ended) return;
+      if (!cleared) {
+        // Bad move: spawn the queued items.
+        spawnFromQueue();
+      }
+    });
   }
 
   // ---- Match detection ----
@@ -966,36 +1025,41 @@
     return matched;
   }
 
-  function resolveMatches() {
-    const board = state.board;
-    const matches = findMatches(board);
-    if (matches.length === 0) {
-      hudItems.textContent = countItems(board);
-      checkWin();
-      return;
-    }
-    state.busy = true;
-    // animate and remove
-    matches.forEach(({ r, c }) => {
-      const ce = cellEl(r, c);
-      if (!ce) return;
-      const front = ce.querySelector('.item.front');
-      if (front) front.classList.add('matched');
-      const spark = document.createElement('div');
-      spark.className = 'spark';
-      ce.appendChild(spark);
-    });
-    setTimeout(() => {
+  // Resolves cascading matches; calls done(anyCleared) when finished.
+  function resolveMatches(done) {
+    let anyCleared = false;
+    function pass() {
+      const board = state.board;
+      const matches = findMatches(board);
+      if (matches.length === 0) {
+        hudItems.textContent = countItems(board);
+        if (anyCleared) checkWin();
+        if (done) done(anyCleared);
+        return;
+      }
+      anyCleared = true;
+      state.busy = true;
       matches.forEach(({ r, c }) => {
-        const cell = board.shelves[r].cells[c];
-        cell.front = cell.back;
-        cell.back = null;
+        const ce = cellEl(r, c);
+        if (!ce) return;
+        const front = ce.querySelector('.item.front');
+        if (front) front.classList.add('matched');
+        const spark = document.createElement('div');
+        spark.className = 'spark';
+        ce.appendChild(spark);
       });
-      renderBoard(board);
-      state.busy = false;
-      // chain into next pass for any new matches
-      resolveMatches();
-    }, 460);
+      setTimeout(() => {
+        matches.forEach(({ r, c }) => {
+          const cell = board.shelves[r].cells[c];
+          cell.front = cell.back;
+          cell.back = null;
+        });
+        renderBoard(board);
+        state.busy = false;
+        pass();
+      }, 460);
+    }
+    pass();
   }
 
   function checkWin() {
@@ -1010,6 +1074,69 @@
       // small beat before showing the panel.
       setTimeout(showLevelClear, 350);
     }
+  }
+
+  // ---- Spawn queue ----
+  const nextItemsEl = document.getElementById('next-items');
+  function genSpawnSet(items) {
+    const id = items[Math.floor(Math.random() * items.length)].id;
+    return [id, id, id];
+  }
+  function renderQueue() {
+    if (!state || !state.queue) { nextItemsEl.innerHTML = ''; return; }
+    nextItemsEl.innerHTML = '';
+    for (const id of state.queue) {
+      const el = document.createElement('div');
+      el.className = 'next-item';
+      el.textContent = itemById(id).e;
+      nextItemsEl.appendChild(el);
+    }
+  }
+
+  function spawnFromQueue() {
+    if (!state || state.ended) return;
+    const board = state.board;
+    const empties = [];
+    for (let r = 0; r < board.shelves.length; r++) {
+      if (board.shelves[r].high) continue;
+      for (let c = 0; c < board.shelves[r].cells.length; c++) {
+        if (board.shelves[r].cells[c].front == null) empties.push({ r, c });
+      }
+    }
+    shuffle(empties);
+    const placedSlots = [];
+    for (const itemId of state.queue) {
+      if (empties.length === 0) break;
+      const slot = empties.pop();
+      board.shelves[slot.r].cells[slot.c].front = itemId;
+      placedSlots.push(slot);
+    }
+    state.queue = genSpawnSet(board.items);
+    renderQueue();
+    renderBoard(board);
+    // little pop animation on freshly spawned cells
+    placedSlots.forEach(({ r, c }) => {
+      const ce = cellEl(r, c);
+      const fr = ce && ce.querySelector('.item.front');
+      if (fr) fr.classList.add('spawning');
+    });
+    // The spawn might land 3 same items on a single shelf -> chain a clear.
+    resolveMatches(() => {
+      if (state.ended) return;
+      // After all clears settle, check if board is full / unrecoverable.
+      checkBoardFull();
+    });
+  }
+
+  function checkBoardFull() {
+    if (!state || state.ended) return;
+    const board = state.board;
+    let empty = 0;
+    for (let r = 0; r < board.shelves.length; r++) {
+      if (board.shelves[r].high) continue;
+      for (const c of board.shelves[r].cells) if (c.front == null) empty++;
+    }
+    if (empty === 0) endRun('full');
   }
 
   // pointer listeners

--- a/shelf-organization.html
+++ b/shelf-organization.html
@@ -213,10 +213,10 @@
 
   .shelf-stack {
     width: 100%;
-    max-width: 460px;
+    max-width: 360px;
     margin: 4px auto 12px;
     display: flex; flex-direction: column;
-    gap: 14px;
+    gap: 12px;
     padding: 8px 6px 12px;
     background: linear-gradient(180deg, #d9b888 0%, #c79a64 100%);
     border: 2px solid var(--wood-edge);
@@ -266,12 +266,12 @@
   }
   .item {
     position: absolute;
-    inset: 4%;
+    inset: 6%;
     display: flex; align-items: center; justify-content: center;
-    font-size: clamp(20px, 6.4vw, 30px);
+    font-size: clamp(34px, 12vw, 56px);
     line-height: 1;
     background: linear-gradient(180deg, #fff8ec 0%, #ffe5b8 100%);
-    border-radius: 6px;
+    border-radius: 8px;
     box-shadow:
       0 2px 0 rgba(0,0,0,0.18),
       inset 0 1px 0 rgba(255,255,255,0.8);
@@ -316,9 +316,9 @@
   .ghost {
     position: fixed;
     left: 0; top: 0;
-    width: 44px; height: 44px;
+    width: 60px; height: 60px;
     display: flex; align-items: center; justify-content: center;
-    font-size: 30px;
+    font-size: 42px;
     background: linear-gradient(180deg, #fff8ec 0%, #ffe5b8 100%);
     border-radius: 8px;
     box-shadow:
@@ -618,53 +618,96 @@
   // board.shelves: array of shelves, each shelf has cols and an array of cells.
   // cell = { front: itemId|null, back: itemId|null }
   // A shelf can be marked .high (unreachable). Some cells can hold a back item.
+  function shuffle(arr) {
+    for (let i = arr.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [arr[i], arr[j]] = [arr[j], arr[i]];
+    }
+    return arr;
+  }
+
   function makeBoard(level) {
     const items = itemsForLevel(level);
     const hard = isHardLevel(level);
-    const cols = 6;
-    const rowsTotal = 4;
+    const cols = 3;
+    const rowsTotal = 6;
     // First shelf is "too high" starting at level 3.
     // Hard levels: top two shelves are unreachable.
     const highRows = new Set();
     if (hard) { highRows.add(0); highRows.add(1); }
     else if (level >= 3) { highRows.add(0); }
 
-    // Density: how full the shelves are (out of 1).
-    let density = Math.min(0.85, 0.55 + level * 0.012);
-    // Depth: chance any given cell has a back item too.
-    let depthChance = level >= 4 ? Math.min(0.32, 0.06 + (level - 4) * 0.015) : 0;
-    if (hard) { density = Math.min(0.92, density + 0.1); depthChance = Math.min(0.5, depthChance + 0.18); }
-
+    // Build empty shelves first.
     const shelves = [];
     for (let r = 0; r < rowsTotal; r++) {
       const cells = [];
-      const isHigh = highRows.has(r);
-      // High shelf: keep mostly full (decorative clutter).
-      const cellDensity = isHigh ? 0.92 : density;
-      for (let c = 0; c < cols; c++) {
-        let front = null, back = null;
-        if (Math.random() < cellDensity) {
-          front = items[Math.floor(Math.random() * items.length)].id;
-          if (!isHigh && Math.random() < depthChance) {
-            back = items[Math.floor(Math.random() * items.length)].id;
-          }
+      for (let c = 0; c < cols; c++) cells.push({ front: null, back: null });
+      shelves.push({ cols, cells, high: highRows.has(r) });
+    }
+
+    // How many "sets of 3" to start with on reachable shelves.
+    // Always a multiple of 3, always leaves at least 1 reachable shelf empty.
+    const reachableShelves = rowsTotal - highRows.size;
+    const reachableCells = reachableShelves * cols;
+    const maxSets = Math.floor(reachableCells / 3) - 1;
+    let sets = Math.min(maxSets, 2 + Math.floor((level - 1) / 2));
+    if (hard) sets = Math.min(maxSets, sets + 1);
+    sets = Math.max(2, sets);
+
+    // Collect reachable front slots; depth slots become eligible at level 4+.
+    const frontSlots = [];
+    for (let r = 0; r < rowsTotal; r++) {
+      if (highRows.has(r)) continue;
+      for (let c = 0; c < cols; c++) frontSlots.push({ r, c });
+    }
+    shuffle(frontSlots);
+
+    const depthChance = level >= 4 ? Math.min(0.35, 0.06 + (level - 4) * 0.02) : 0;
+    const placeBack = (itemId) => {
+      // Look for a cell with a front item but no back; place itemId behind.
+      const candidates = [];
+      for (let r = 0; r < rowsTotal; r++) {
+        if (highRows.has(r)) continue;
+        for (let c = 0; c < cols; c++) {
+          const cell = shelves[r].cells[c];
+          if (cell.front != null && cell.back == null) candidates.push({ r, c });
         }
-        cells.push({ front, back });
       }
-      shelves.push({ cols, cells, high: isHigh });
-    }
-    // Avoid a starting board with zero empty reachable spots.
-    let openCount = 0;
-    shelves.forEach(sh => { if (!sh.high) sh.cells.forEach(c => { if (!c.front) openCount++; }); });
-    if (openCount < 2) {
-      // force a couple of empties on a non-high shelf
-      const target = shelves.find(s => !s.high);
-      if (target) {
-        target.cells[0].front = null; target.cells[0].back = null;
-        target.cells[target.cells.length - 1].front = null;
-        target.cells[target.cells.length - 1].back = null;
+      if (candidates.length === 0) return false;
+      const slot = candidates[Math.floor(Math.random() * candidates.length)];
+      shelves[slot.r].cells[slot.c].back = itemId;
+      return true;
+    };
+
+    for (let s = 0; s < sets; s++) {
+      const itemId = items[Math.floor(Math.random() * items.length)].id;
+      let placed = 0;
+      while (placed < 3) {
+        if (Math.random() < depthChance && placeBack(itemId)) {
+          placed++;
+          continue;
+        }
+        if (frontSlots.length === 0) {
+          // fall back to a back-slot if any.
+          if (placeBack(itemId)) { placed++; continue; }
+          break;
+        }
+        const slot = frontSlots.pop();
+        shelves[slot.r].cells[slot.c].front = itemId;
+        placed++;
       }
     }
+
+    // Decorate high shelves with random items (not part of clearable count).
+    for (let r = 0; r < rowsTotal; r++) {
+      if (!highRows.has(r)) continue;
+      for (let c = 0; c < cols; c++) {
+        if (Math.random() < 0.92) {
+          shelves[r].cells[c].front = items[Math.floor(Math.random() * items.length)].id;
+        }
+      }
+    }
+
     return { shelves, level, items, hard };
   }
 
@@ -906,21 +949,18 @@
 
   // ---- Match detection ----
   function findMatches(board) {
-    const matched = []; // list of {r,c}
+    // A reachable shelf clears when every cell on it shares the same front item.
+    const matched = [];
     for (let r = 0; r < board.shelves.length; r++) {
-      if (board.shelves[r].high) continue;
-      const cells = board.shelves[r].cells;
-      let runStart = 0;
-      for (let c = 1; c <= cells.length; c++) {
-        const prev = cells[c - 1].front;
-        const curr = c < cells.length ? cells[c].front : null;
-        if (c === cells.length || curr !== prev || prev == null) {
-          const len = c - runStart;
-          if (prev != null && len >= 3) {
-            for (let k = runStart; k < c; k++) matched.push({ r, c: k });
-          }
-          runStart = c;
-        }
+      const shelf = board.shelves[r];
+      if (shelf.high) continue;
+      const cells = shelf.cells;
+      const first = cells[0].front;
+      if (first == null) continue;
+      let allSame = true;
+      for (const c of cells) if (c.front !== first) { allSame = false; break; }
+      if (allSame) {
+        for (let i = 0; i < cells.length; i++) matched.push({ r, c: i });
       }
     }
     return matched;


### PR DESCRIPTION
## Summary
Builds on the merged Shelf Organization game with a supermarket-sorter style overhaul:
- **3-wide shelves** so a match equals a full shelf of one item — visualizing the rule directly.
- **Multiples-of-3 generation**: every starting board is constructed from sets of three same items, so every level is cleanable from the start.
- **Visible NEXT tray** shows the three identical items queued up to spawn next.
- **Bad-move consequence**: if a move doesn't clear a shelf, the queued three drop into random empty cells (and can chain a clear), then a fresh trio queues up.
- **Board-full lose**: if a spawn leaves zero empty reachable cells, the run ends with a "Pantry Overflowed!" screen — alongside the existing time-out.

## Test plan
- [ ] Open the game, confirm shelves are 3 cells wide and a NEXT tray shows three same items below the board.
- [ ] Make a non-clearing move and verify the three queued items drop into random empty cells, then NEXT refreshes.
- [ ] Fill a shelf with three matching items and confirm it clears (no spawn since the move was a clear).
- [ ] Force the board to fill up and verify the run ends with "Pantry Overflowed!".
- [ ] Reach level 5 and confirm a new item type unlocks; reach level 7 and confirm the HARD banner with two locked top rows.
- [ ] Verify back items still appear at level 4+ behind front items and rise when uncovered.

https://claude.ai/code/session_012ajzjW4H8KvXNj9CZbnbsQ

---
_Generated by [Claude Code](https://claude.ai/code/session_012ajzjW4H8KvXNj9CZbnbsQ)_